### PR TITLE
Support Python 3.11

### DIFF
--- a/allcities/cityset.py
+++ b/allcities/cityset.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
-from collections import Set
 import logging
 import operator
 import random
@@ -11,7 +10,8 @@ from allcities.city import City
 
 logger = logging.getLogger('allcities.geonamesdata')
 
-class CitySet(Set):
+
+class CitySet(set):
     """
     Wrapper that represents a set of cities.
     """


### PR DESCRIPTION
Is this all we need to do for this library to be usable in Python 3.11? Currently it fails with:

```
>>> import allcities
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/benquigley/local/allcities/allcities/__init__.py", line 14, in <module>
    from .core import all_cities as cities
  File "/Users/benquigley/local/allcities/allcities/core.py", line 18, in <module>
    from allcities.cityset import CitySet
  File "/Users/benquigley/local/allcities/allcities/cityset.py", line 4, in <module>
    from collections import Set
ImportError: cannot import name 'Set' from 'collections' (/Users/benquigley/.pyenv/versions/3.10.8/lib/python3.10/collections/__init__.py)
```

`Set` is no longer importable from typing as of Python 3.11. We should just be able to inherit from the builtin type, and this change fixes the error.